### PR TITLE
fix(security): sanitize media url parameter and reject attacks DEV-1249

### DIFF
--- a/app/controllers/form.js
+++ b/app/controllers/form.js
@@ -5,6 +5,7 @@ const fs = require( 'fs' );
 //const debug = require( 'debug' )( 'form controller' );
 const manifest = require( '../models/formManifest' );
 const path = require( 'path' );
+const utils = require( '../lib/utils' );
 const formStoragePath = path.resolve( __dirname, '../../storage/forms' );
 
 module.exports = function( app ) {
@@ -43,7 +44,16 @@ router
             .catch( next );
     } )
     .get( '/:formId/media/:filename', ( req, res, next ) => {
-        const file = fs.createReadStream(path.join( formStoragePath, req.formId + '-media', req.filename ) );
-        res.contentType(req.params.filename);
-        file.pipe( res );
+        try {
+            // Sanitize the filename to prevent path traversal attacks
+            const sanitizedFilename = utils.sanitizeFilename( req.filename );
+            const file = fs.createReadStream( path.join( formStoragePath, req.formId + '-media', sanitizedFilename ) );
+            res.contentType( req.params.filename );
+            file.pipe( res );
+        } catch ( error ) {
+            // Return 400 Bad Request for invalid filenames
+            const err = new Error( error.message );
+            err.status = 400;
+            next( err );
+        }
     } );

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1,12 +1,48 @@
-const crypto = require( 'crypto' );
+const crypto = require("crypto");
+const path = require("path");
 //const debug = require( 'debug' )( 'utils' );
 
-function _md5( message ) {
-    let hash = crypto.createHash( 'md5' );
-    hash.update( message );
-    return hash.digest( 'hex' );
+function _md5(message) {
+  let hash = crypto.createHash("md5");
+  hash.update(message);
+  return hash.digest("hex");
+}
+
+/**
+ * Sanitizes a filename to prevent path traversal attacks
+ * @param {string} filename - The filename to sanitize
+ * @returns {string} - The sanitized filename
+ * @throws {Error} - If the filename contains path traversal patterns
+ */
+function _sanitizeFilename(filename) {
+  if (!filename || typeof filename !== "string") {
+    throw new Error("Invalid filename provided");
+  }
+
+  // Check for null bytes
+  if (filename.includes("\0")) {
+    throw new Error("Invalid filename provided");
+  }
+
+  // Check for path traversal patterns
+  if (
+    filename.includes("..") ||
+    filename.includes("/") ||
+    filename.includes("\\")
+  ) {
+    throw new Error("Invalid filename provided");
+  }
+
+  // Additional check: use path.normalize and ensure result doesn't escape intended directory
+  const normalized = path.normalize(filename);
+  if (normalized !== filename || normalized.includes("..")) {
+    throw new Error("Invalid filename provided");
+  }
+
+  return filename;
 }
 
 module.exports = {
-    md5: _md5
+  md5: _md5,
+  sanitizeFilename: _sanitizeFilename,
 };

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -2,10 +2,10 @@ const crypto = require("crypto");
 const path = require("path");
 //const debug = require( 'debug' )( 'utils' );
 
-function _md5(message) {
-  let hash = crypto.createHash("md5");
-  hash.update(message);
-  return hash.digest("hex");
+function _md5( message ) {
+    let hash = crypto.createHash( 'md5' );
+    hash.update( message );
+    return hash.digest( 'hex' );
 }
 
 /**

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -2,10 +2,10 @@ const crypto = require("crypto");
 const path = require("path");
 //const debug = require( 'debug' )( 'utils' );
 
-function _md5( message ) {
-    let hash = crypto.createHash( 'md5' );
-    hash.update( message );
-    return hash.digest( 'hex' );
+function _md5(message) {
+  let hash = crypto.createHash("md5");
+  hash.update(message);
+  return hash.digest("hex");
 }
 
 /**
@@ -24,22 +24,21 @@ function _sanitizeFilename(filename) {
     throw new Error("Invalid filename provided");
   }
 
-  // Check for path traversal patterns
+  // Sanitize fileName to prevent path traversal attacks
+  // Use path.normalize and path.basename to ensure only the filename is used
+  const sanitizedFileName = path.basename(path.normalize(filename));
+
+  // Reject if the normalized path differs significantly from the original
+  // This catches path separators or path traversal (.., ../, ..%, etc.)
   if (
-    filename.includes("..") ||
-    filename.includes("/") ||
-    filename.includes("\\")
+    !sanitizedFileName ||
+    sanitizedFileName !== filename ||
+    /[/\\]|\.\./.test(filename)
   ) {
-    throw new Error("Invalid filename provided");
+    throw new Error("Invalid file provided");
   }
 
-  // Additional check: use path.normalize and ensure result doesn't escape intended directory
-  const normalized = path.normalize(filename);
-  if (normalized !== filename || normalized.includes("..")) {
-    throw new Error("Invalid filename provided");
-  }
-
-  return filename;
+  return sanitizedFileName;
 }
 
 module.exports = {

--- a/test/path-traversal-protection.spec.js
+++ b/test/path-traversal-protection.spec.js
@@ -1,0 +1,95 @@
+/* eslint-env mocha */
+
+const chai = require("chai");
+const expect = chai.expect;
+const utils = require("../app/lib/utils");
+
+describe("Path Traversal Protection", () => {
+  describe("sanitizeFilename function", () => {
+    it("should allow valid filenames", () => {
+      const validFilenames = [
+        "image.jpg",
+        "document.pdf",
+        "file123.txt",
+        "my-file_name.png",
+        "test.xml",
+      ];
+
+      validFilenames.forEach((filename) => {
+        expect(() => utils.sanitizeFilename(filename)).to.not.throw();
+        expect(utils.sanitizeFilename(filename)).to.equal(filename);
+      });
+    });
+
+    it("should block path traversal attempts with ../", () => {
+      const maliciousFilenames = [
+        "../../../etc/passwd",
+        "..\\..\\windows\\system32\\config\\sam",
+        "file../other.txt",
+        "..file.txt",
+        "file..txt",
+      ];
+
+      maliciousFilenames.forEach((filename) => {
+        expect(() => utils.sanitizeFilename(filename)).to.throw(
+          "Invalid filename provided"
+        );
+      });
+    });
+
+    it("should block filenames with directory separators", () => {
+      const maliciousFilenames = [
+        "folder/file.txt",
+        "folder\\file.txt",
+        "/etc/passwd",
+        "\\windows\\system32\\hosts",
+        "some/path/to/file.jpg",
+      ];
+
+      maliciousFilenames.forEach((filename) => {
+        expect(() => utils.sanitizeFilename(filename)).to.throw(
+          "Invalid filename provided"
+        );
+      });
+    });
+
+    it("should block filenames with null bytes", () => {
+      const maliciousFilenames = [
+        "file.txt\0",
+        "file\0.txt",
+        "\0file.txt",
+        "file.txt\0/../../../etc/passwd",
+      ];
+
+      maliciousFilenames.forEach((filename) => {
+        expect(() => utils.sanitizeFilename(filename)).to.throw();
+      });
+    });
+
+    it("should handle invalid input types", () => {
+      const invalidInputs = [null, undefined, 123, {}, [], ""];
+
+      invalidInputs.forEach((input) => {
+        expect(() => utils.sanitizeFilename(input)).to.throw(
+          "Invalid filename provided"
+        );
+      });
+    });
+
+    it("should block URL-encoded path traversal attempts", () => {
+      const encodedMaliciousFilenames = [
+        "%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+        "file%2e%2e%2fother.txt",
+      ];
+
+      // Note: URL decoding should be handled by Express before reaching our sanitizer
+      // These tests verify our sanitizer would catch already-decoded malicious patterns
+      encodedMaliciousFilenames.forEach((filename) => {
+        const decoded = decodeURIComponent(filename);
+        expect(() => utils.sanitizeFilename(decoded)).to.throw(
+          "Invalid filename provided"
+        );
+      });
+    });
+  });
+});

--- a/test/path-traversal-protection.spec.js
+++ b/test/path-traversal-protection.spec.js
@@ -32,7 +32,7 @@ describe("Path Traversal Protection", () => {
 
       maliciousFilenames.forEach((filename) => {
         expect(() => utils.sanitizeFilename(filename)).to.throw(
-          "Invalid filename provided"
+          "Invalid file provided"
         );
       });
     });
@@ -48,7 +48,7 @@ describe("Path Traversal Protection", () => {
 
       maliciousFilenames.forEach((filename) => {
         expect(() => utils.sanitizeFilename(filename)).to.throw(
-          "Invalid filename provided"
+          "Invalid file provided"
         );
       });
     });
@@ -87,7 +87,7 @@ describe("Path Traversal Protection", () => {
       encodedMaliciousFilenames.forEach((filename) => {
         const decoded = decodeURIComponent(filename);
         expect(() => utils.sanitizeFilename(decoded)).to.throw(
-          "Invalid filename provided"
+          "Invalid file provided"
         );
       });
     });


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
2. [x] assign yourself
3. [x] fill in the template below and delete template comments
4. [x] update all related docs (README, inline, etc.), if any
5. [x] review thyself: read the diff and repro the preview as written
6. [x] undraft PR & confirm that CI passes
7. [x] request reviewers & improve according to review
8. [ ] delete this section before merging

### 📣 Summary

Fixed a path traversal potential vulnerability in the media file serving endpoint that allowed attackers to possibly read arbitrary files from the server filesystem.

### 💭 Notes

Express implements some URL normalization that acts as a first security layer, blocking the tested path traversal attack scenarios, but we're still adding this sanitization and protection as a good measure to add security to the server code.

